### PR TITLE
Granular change on readme plus change for redirect on save of auth form

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This client is a WIP to make entering data to redmine a much more accurate and e
 To run a local development instance, you will need docker and docker-compose installed.
 
 - Clone the project
-- Run npm install to install the projects dependancies
+- Run `npm install` to install the projects dependancies
 - Run `docker-compose up` to start the application along with a local redmine instance
 - Navigate to http://localhost:3002 to see the local redmine instance
 - Use `test-user` and `test-user` to log in to a user account

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This client is a WIP to make entering data to redmine a much more accurate and e
 To run a local development instance, you will need docker and docker-compose installed.
 
 - Clone the project
-- Run `npm install` to install the projects dependancies
+- Run `npm install` to install the applications dependancies
 - Run `docker-compose up` to start the application along with a local redmine instance
 - Navigate to http://localhost:3002 to see the local redmine instance
 - Use `test-user` and `test-user` to log in to a user account

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ This client is a WIP to make entering data to redmine a much more accurate and e
 To run a local development instance, you will need docker and docker-compose installed.
 
 - Clone the project
+- Run npm install to install the projects dependancies
 - Run `docker-compose up` to start the application along with a local redmine instance
 - Navigate to http://localhost:3002 to see the local redmine instance
 - Use `test-user` and `test-user` to log in to a user account

--- a/src/components/Authenticate/index.js
+++ b/src/components/Authenticate/index.js
@@ -8,7 +8,7 @@ const { Title, Text } = Typography;
 export const Authenticate = props => (
   <>
     {props.location.isRedirected && alert('Please provide Redmine settings.')}
-    <AuthenticationTutorial />
+    <AuthenticationTutorial history={props.history} />
     <Title level={2}>
       <Icon type="setting" /> - Authenticate
     </Title>
@@ -20,6 +20,6 @@ export const Authenticate = props => (
       </strong>
     </Text>
     <Divider />
-    <AuthenticationForm />
+    <AuthenticationForm history={props.history} />
   </>
 );

--- a/src/components/AuthenticationForm/index.js
+++ b/src/components/AuthenticationForm/index.js
@@ -21,7 +21,8 @@ function UnconnectedAuthenticationForm({
   storedKey,
   storedAddress,
   updateRedmineAddress,
-  updateRedmineKey
+  updateRedmineKey,
+  history
 }) {
   const [
     redmineApiKey,
@@ -35,6 +36,7 @@ function UnconnectedAuthenticationForm({
     addressValid,
     addressPristine
   ] = useInputWithValidation(isSecureUrl, storedAddress);
+  const redirectToEntries = () => history.push('/entries');
 
   return (
     <Form
@@ -42,6 +44,7 @@ function UnconnectedAuthenticationForm({
         e.preventDefault();
         updateRedmineAddress(redmineAddress);
         updateRedmineKey(redmineApiKey);
+        redirectToEntries();
       }}
     >
       <Form.Item
@@ -89,6 +92,7 @@ function UnconnectedAuthenticationForm({
           onSubmit={() => {
             updateRedmineAddress(redmineAddress);
             updateRedmineKey(redmineApiKey);
+            redirectToEntries();
           }}
         >
           Save


### PR DESCRIPTION
Changes I noticed when playing about that might be useful although I'll let you be the judge of that!

- I've added to run `npm install` before running `docker-compose up` otherwise you'll get an error with react-app-rewired
- Secondly, when adding your redmine address and API key I wasn't sure whether they were added or not after clicking save so I thought redirecting to entries might be a good idea? I tried to follow the react-router way of using the `<Redirect />` component as used on /src/components/Entries/index.js but no luck there. 

No worries if you'd rather keep it as it is or if you have better ideas. Just two things I noticed when using the application :)